### PR TITLE
Fix for dev purrr

### DIFF
--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -44,9 +44,8 @@ test_that("rlmap returns NULL unaltered", {
   expect_null(rlmap(list(foo=NULL), function(x) x)$foo)
 })
 
-test_that("vec_depth doesn't attempt to measure the depth of errors", {
+test_that("vec_depth can measure the depth of errors", {
   err <- tryCatch(stop("oops"), error=function(e) {e})
-  expect_error(purrr::vec_depth(err))
   expect_equal(vec_depth(err), 1)
 })
 


### PR DESCRIPTION
Since `vec_depth()` now does work with captured error objects, because it's now better aligned with what you can `pluck()`.